### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,20 @@
+{
+  "name": "Automotive ADAS + Infotainment Simulation",
+  "install": "./.cursor/install.sh",
+  "terminals": [
+    {
+      "name": "Backend API",
+      "command": "python3 -m uvicorn backend.api.main:app --host 0.0.0.0 --port 8000 --reload",
+      "description": "FastAPI ADAS simulation backend on port 8000."
+    },
+    {
+      "name": "Web App",
+      "command": "cd web-app && npm run dev -- --host 0.0.0.0 --port 5173",
+      "description": "Vite React dashboard on port 5173 (proxies /api to the backend)."
+    }
+  ],
+  "ports": [
+    { "name": "Backend API (FastAPI)", "port": 8000 },
+    { "name": "Web App (Vite)", "port": 5173 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Idempotent dependency refresh for the Automotive ADAS + Infotainment monorepo.
+# Runs after the repository is checked out. Safe to re-run.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[install] Python dependencies (backend API + ADAS simulation engine)"
+python3 -m pip install --upgrade pip
+python3 -m pip install -r backend/requirements.txt -r ADAS_SIL_System/requirements.txt
+
+echo "[install] web-app dependencies"
+(cd web-app && npm ci)
+
+echo "[install] mobile-app dependencies"
+(cd mobile-app && npm ci)
+
+echo "[install] Complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for the Automotive ADAS + Infotainment monorepo so future agents boot with all dependencies installed and the backend API + web dashboard running.

### Added

- `.cursor/environment.json` — install hook, two long-running terminals (Backend API on `8000`, Web App on `5173`), and exposed ports.
- `.cursor/install.sh` — idempotent dependency refresh: Python deps (`backend/requirements.txt` + `ADAS_SIL_System/requirements.txt`), `web-app` and `mobile-app` npm installs.

### Design notes

- Uses Cursor's default base image (already provides Python 3.12, Node 22, Java 21) — no custom Dockerfile needed.
- Python deps install to the user site; services run via `python3 -m uvicorn` to avoid PATH issues.
- The Vite dev server proxies `/api` to the FastAPI backend, so the dashboard works end-to-end.
- Mobile (Expo) deps are installed for development; the Expo dev server isn't auto-started since it needs a device/emulator.

## Validation

| Check | Result |
| --- | --- |
| `pytest backend/tests ADAS_SIL_System/tests` | 77 passed |
| web-app `npm run lint` | clean |
| web-app `npm test` (vitest) | 2 passed |
| web-app `npm run build` | built (41 modules) |
| Install script idempotence | ran twice, clean |
| Backend API | `/scenarios` (9), `/test-cases` (14), `POST /test-cases/run` → PASS |
| Web dashboard e2e | Run All Tests → 11/14 PASS; trace chart + validation checks render |
| Draft environment build | SUCCEEDED (`install.sh`: py deps + web 405 pkgs + mobile 1249 pkgs) |

The 3 FAIL results in "Run All Tests" are the simulation's own deterministic pass/fail criteria (not an environment issue).

### End-to-end demo (web dashboard → Vite proxy → FastAPI → simulation engine)

[web_dashboard_e2e_run_tests.mp4](https://cursor.com/agents/bc-049bb466-a3ac-486c-b18b-6df2414bdf41/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_dashboard_e2e_run_tests.mp4)

Highway test showing the speed trace chart and per-check validation:

[Highway test trace chart and validation checks](https://cursor.com/agents/bc-049bb466-a3ac-486c-b18b-6df2414bdf41/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_trace_chart_highway.webp)

Run All Tests results summary (11/14) and validation panel:

[Results summary and validation checks](https://cursor.com/agents/bc-049bb466-a3ac-486c-b18b-6df2414bdf41/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_results_summary.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-049bb466-a3ac-486c-b18b-6df2414bdf41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-049bb466-a3ac-486c-b18b-6df2414bdf41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

