### PR TITLE
Fix ADAS/infotainment bugs + lasting review feedback for AAOS

### DIFF
--- a/ADAS_SIL_System/core/adas_features/acc.py
+++ b/ADAS_SIL_System/core/adas_features/acc.py
@@ -54,10 +54,10 @@ class AdaptiveCruiseControl:
         self.ki_distance = 0.05
         self.kd_distance = 0.15
 
-        # State
-        self.enabled = False
+        # State — honor config so API/simulator "enabled" actually activates ACC
+        self.enabled = bool(self.config.get('enabled', False))
         self.active = False
-        self.set_speed = 100.0 / 3.6  # 100 km/h default
+        self.set_speed = float(self.config.get('set_speed', 100.0 / 3.6))
         self.target_speed = self.set_speed
         self.target_acceleration = 0.0
 
@@ -105,6 +105,7 @@ class AdaptiveCruiseControl:
             # Speed control mode
             self._update_speed_control_mode(current_speed, dt)
 
+        # Active whenever enabled so longitudinal control is applied in SIL
         self.active = True
         return self._get_status()
 
@@ -260,12 +261,24 @@ class AdaptiveCruiseControl:
         Args:
             current_speed: Current vehicle speed (m/s)
         """
-        if current_speed >= self.min_speed:
-            self.enabled = True
+        # Allow enable below min_speed for SIL bootstrap; stay inactive until speed OK
+        self.enabled = True
+        configured = self.config.get('set_speed')
+        if configured is not None:
+            # Keep explicit config set-speed (do not clobber with current speed)
+            self.set_speed = float(configured)
+            logger.info(
+                f"ACC enabled with configured set_speed={self.set_speed * 3.6:.1f} km/h "
+                f"(current={current_speed * 3.6:.1f} km/h)"
+            )
+        elif current_speed >= self.min_speed:
             self.set_speed = current_speed
             logger.info(f"ACC enabled at {current_speed * 3.6:.1f} km/h")
         else:
-            logger.warning(f"ACC requires minimum speed of {self.min_speed * 3.6:.1f} km/h")
+            logger.info(
+                f"ACC enabled (below min speed {self.min_speed * 3.6:.1f} km/h); "
+                f"set_speed={self.set_speed * 3.6:.1f} km/h"
+            )
 
     def disable(self):
         """Disable ACC system."""

--- a/ADAS_SIL_System/core/adas_features/blind_spot_detection.py
+++ b/ADAS_SIL_System/core/adas_features/blind_spot_detection.py
@@ -109,48 +109,78 @@ class BlindSpotDetection:
             if sensor_type not in ['radar', 'camera']:
                 continue
 
-            classification = detection.get('classification', '')
-            if 'vehicle' not in classification.lower():
+            # Radar targets are vehicles by default; camera needs classification or vehicle type
+            classification = str(detection.get('classification', '') or detection.get('detection_type', ''))
+            if sensor_type == 'camera':
+                if classification and 'vehicle' not in classification.lower():
+                    # Skip signs / lanes / unknown camera objects
+                    if classification.lower() not in ('', 'object', 'unknown'):
+                        continue
+                elif not classification and detection.get('detection_type') == 'traffic_sign':
+                    continue
+            # Radar: treat as vehicle unless explicitly marked otherwise
+            elif classification and 'vehicle' not in classification.lower() and classification.lower() not in ('', 'object', 'unknown'):
                 continue
 
-            # Get detection position in vehicle frame
-            target_pos = np.array([detection.get('x', 0.0),
-                                  detection.get('y', 0.0)])
-
-            # Convert to ego vehicle frame
-            rel_x, rel_y = self._global_to_vehicle_frame(
-                target_pos, vehicle_pos, vehicle_yaw
-            )
-
-            # Calculate angle and range
-            angle = np.arctan2(rel_y, rel_x)
-            range_dist = np.sqrt(rel_x**2 + rel_y**2)
+            # Prefer vehicle-frame pose from range/azimuth (radar native)
+            if 'range' in detection and 'azimuth' in detection and 'x' not in detection:
+                range_dist = float(detection.get('range', 0.0))
+                angle = float(detection.get('azimuth', 0.0))
+                rel_x = range_dist * np.cos(angle)
+                rel_y = range_dist * np.sin(angle)
+            else:
+                # x/y may already be vehicle-frame or global depending on source
+                if detection.get('frame') == 'vehicle' or (
+                    'range' in detection and 'azimuth' in detection
+                ):
+                    # Derive from polar if both present for consistency
+                    if 'range' in detection and 'azimuth' in detection:
+                        range_dist = float(detection['range'])
+                        angle = float(detection['azimuth'])
+                        rel_x = range_dist * np.cos(angle)
+                        rel_y = range_dist * np.sin(angle)
+                    else:
+                        rel_x = float(detection.get('x', 0.0))
+                        rel_y = float(detection.get('y', 0.0))
+                        angle = np.arctan2(rel_y, rel_x)
+                        range_dist = np.sqrt(rel_x**2 + rel_y**2)
+                else:
+                    target_pos = np.array([
+                        float(detection.get('x', 0.0)),
+                        float(detection.get('y', 0.0)),
+                    ])
+                    # If coords look like global (far from origin relative to ego), convert
+                    rel_x, rel_y = self._global_to_vehicle_frame(
+                        target_pos, vehicle_pos, vehicle_yaw
+                    )
+                    angle = np.arctan2(rel_y, rel_x)
+                    range_dist = np.sqrt(rel_x**2 + rel_y**2)
 
             # Check blind spot zones
             if self._is_in_left_zone(angle, range_dist):
                 self.left_blind_spot_occupied = True
                 self.warning_active = True
                 self.warning_side = 'left'
-                logger.info(f"BSD: Vehicle detected in LEFT blind spot")
+                logger.debug("BSD: Vehicle detected in LEFT blind spot")
 
             elif self._is_in_right_zone(angle, range_dist):
                 self.right_blind_spot_occupied = True
                 self.warning_active = True
                 self.warning_side = 'right'
-                logger.info(f"BSD: Vehicle detected in RIGHT blind spot")
+                logger.debug("BSD: Vehicle detected in RIGHT blind spot")
 
             elif self._is_in_rear_zone(angle, range_dist):
                 self.rear_blind_spot_occupied = True
                 if not self.left_blind_spot_occupied and not self.right_blind_spot_occupied:
                     self.warning_active = True
                     self.warning_side = 'rear'
-                logger.info(f"BSD: Vehicle detected in REAR zone")
+                logger.debug("BSD: Vehicle detected in REAR zone")
 
             # Track detection
             self.detected_vehicles[obj_id] = {
                 'angle': angle,
                 'range': range_dist,
-                'velocity': detection.get('velocity', 0.0),
+                'velocity': detection.get('velocity', detection.get('radial_velocity', 0.0)),
                 'timestamp': current_time
             }
 

--- a/ADAS_SIL_System/core/adas_features/traffic_sign_recognition.py
+++ b/ADAS_SIL_System/core/adas_features/traffic_sign_recognition.py
@@ -114,10 +114,10 @@ class TrafficSignRecognition:
                 - active_sign_timeout: Time to keep active sign in memory (default: 5.0s)
         """
         self.config = config or {}
-        self.enabled = False
+        self.enabled = bool(self.config.get('enabled', False))
         self.status = {
             'system': 'traffic_sign_recognition',
-            'enabled': False,
+            'enabled': self.enabled,
             'active': False,
             'signs_detected': 0,
             'current_speed_limit': None,
@@ -239,44 +239,116 @@ class TrafficSignRecognition:
         for detection in sensor_data:
             if detection.get('sensor_type') != 'camera':
                 continue
-            
-            # Check if this is a traffic sign detection
-            sign_class = detection.get('sign_class')
-            if not sign_class:
-                continue
-            
-            # Map detected class to TrafficSignType
-            sign_type = self._classify_sign(sign_class)
+
+            # Accept camera schema (sign_type/sign_value) and legacy (sign_class)
+            if detection.get('detection_type') not in (None, 'traffic_sign', 'sign'):
+                # Skip non-sign camera detections (vehicles, lanes, etc.)
+                if not detection.get('sign_class') and not detection.get('sign_type'):
+                    continue
+
+            sign_type = self._resolve_sign_type(detection)
             if not sign_type:
                 continue
-            
-            # Extract detection parameters
-            distance = detection.get('distance', 50.0)
-            confidence = detection.get('confidence', 0.9)
+
+            # Prefer range from camera detections; fall back to distance
+            distance = float(detection.get('range', detection.get('distance', 50.0)))
+            confidence = float(detection.get('confidence', 0.9))
             direction = detection.get('direction', 'ahead')
-            x = detection.get('x', vehicle_state.get('position', [0, 0])[0])
-            y = detection.get('y', vehicle_state.get('position', [0, 0])[1])
-            
-            # Apply filtering
+
+            # Safe position defaults — vehicle_state['position'] is a dict, not a list
+            pos = vehicle_state.get('position') or {}
+            if isinstance(pos, dict):
+                default_x = float(pos.get('x', 0.0))
+                default_y = float(pos.get('y', 0.0))
+            elif isinstance(pos, (list, tuple)) and len(pos) >= 2:
+                default_x, default_y = float(pos[0]), float(pos[1])
+            else:
+                default_x, default_y = 0.0, 0.0
+
+            x = float(detection.get('x', default_x))
+            y = float(detection.get('y', default_y))
+
             if confidence < self.min_confidence:
                 continue
-            
+
             if distance > self.max_detection_range:
                 continue
-            
-            # Create sign object
-            sign = TrafficSign(
-                sign_type=sign_type,
-                position=(x, y),
-                distance=distance,
-                confidence=confidence,
-                direction=direction
+
+            detected_signs.append(
+                TrafficSign(
+                    sign_type=sign_type,
+                    position=(x, y),
+                    distance=distance,
+                    confidence=confidence,
+                    direction=direction,
+                )
             )
-            
-            detected_signs.append(sign)
-        
+
         return detected_signs
-    
+
+    def _resolve_sign_type(self, detection: Dict) -> Optional[TrafficSignType]:
+        """Map camera/legacy detection fields to TrafficSignType."""
+        # Explicit class string (legacy / MIL)
+        sign_class = detection.get('sign_class')
+        if sign_class:
+            classified = self._classify_sign(str(sign_class))
+            if classified:
+                return classified
+
+        # Camera sensor emits sign_type + optional numeric sign_value
+        sign_type_raw = detection.get('sign_type')
+        sign_value = detection.get('sign_value')
+        if sign_type_raw is None and sign_value is None:
+            return None
+
+        type_str = str(sign_type_raw or '').lower().strip()
+
+        # Numeric speed limit from camera value
+        if sign_value is not None:
+            try:
+                speed = int(float(sign_value))
+                speed_key = f'speed_{speed}'
+                classified = self._classify_sign(speed_key)
+                if classified:
+                    return classified
+                # Also try enum name pattern
+                enum_name = f'SPEED_LIMIT_{speed}'
+                if hasattr(TrafficSignType, enum_name):
+                    return getattr(TrafficSignType, enum_name)
+            except (TypeError, ValueError):
+                pass
+
+        # String type aliases from scenarios / camera
+        aliases = {
+            'speed_limit': None,  # needs value
+            'speed': None,
+            'stop': TrafficSignType.STOP_SIGN,
+            'stop_sign': TrafficSignType.STOP_SIGN,
+            'yield': TrafficSignType.YIELD_SIGN,
+            'yield_sign': TrafficSignType.YIELD_SIGN,
+            'pedestrian': TrafficSignType.PEDESTRIAN_CROSSING,
+            'pedestrian_crossing': TrafficSignType.PEDESTRIAN_CROSSING,
+            'construction': TrafficSignType.CONSTRUCTION_ZONE,
+            'construction_zone': TrafficSignType.CONSTRUCTION_ZONE,
+            'school': TrafficSignType.SCHOOL_ZONE,
+            'school_zone': TrafficSignType.SCHOOL_ZONE,
+            'curve_left': TrafficSignType.CURVE_LEFT,
+            'curve_right': TrafficSignType.CURVE_RIGHT,
+            'slippery': TrafficSignType.SLIPPERY_ROAD,
+            'slippery_road': TrafficSignType.SLIPPERY_ROAD,
+            'merge': TrafficSignType.MERGE,
+            'exit': TrafficSignType.EXIT,
+        }
+        if type_str in aliases and aliases[type_str] is not None:
+            return aliases[type_str]
+
+        # Direct enum value match (e.g. "speed_limit_50")
+        for member in TrafficSignType:
+            if member.value == type_str or member.name.lower() == type_str:
+                return member
+
+        return self._classify_sign(type_str)
+
     def _classify_sign(self, sign_class: str) -> Optional[TrafficSignType]:
         """
         Classify sign from detected class string
@@ -301,6 +373,18 @@ class TrafficSignRecognition:
             'speed_110': TrafficSignType.SPEED_LIMIT_110,
             'speed_120': TrafficSignType.SPEED_LIMIT_120,
             'speed_130': TrafficSignType.SPEED_LIMIT_130,
+            'speed_limit_20': TrafficSignType.SPEED_LIMIT_20,
+            'speed_limit_30': TrafficSignType.SPEED_LIMIT_30,
+            'speed_limit_40': TrafficSignType.SPEED_LIMIT_40,
+            'speed_limit_50': TrafficSignType.SPEED_LIMIT_50,
+            'speed_limit_60': TrafficSignType.SPEED_LIMIT_60,
+            'speed_limit_70': TrafficSignType.SPEED_LIMIT_70,
+            'speed_limit_80': TrafficSignType.SPEED_LIMIT_80,
+            'speed_limit_90': TrafficSignType.SPEED_LIMIT_90,
+            'speed_limit_100': TrafficSignType.SPEED_LIMIT_100,
+            'speed_limit_110': TrafficSignType.SPEED_LIMIT_110,
+            'speed_limit_120': TrafficSignType.SPEED_LIMIT_120,
+            'speed_limit_130': TrafficSignType.SPEED_LIMIT_130,
             'stop': TrafficSignType.STOP_SIGN,
             'yield': TrafficSignType.YIELD_SIGN,
             'pedestrian': TrafficSignType.PEDESTRIAN_CROSSING,
@@ -312,8 +396,8 @@ class TrafficSignRecognition:
             'merge': TrafficSignType.MERGE,
             'exit': TrafficSignType.EXIT,
         }
-        
-        return classification_map.get(sign_class)
+
+        return classification_map.get(sign_class.lower().strip() if sign_class else '')
     
     def _update_speed_limit(self, current_time: float) -> None:
         """Extract speed limit from detected signs"""

--- a/ADAS_SIL_System/core/adas_features/trailer_assistance.py
+++ b/ADAS_SIL_System/core/adas_features/trailer_assistance.py
@@ -82,12 +82,18 @@ class TrailerAssistance:
             Dictionary with trailer assistance status
         """
         current_speed = vehicle_state['velocity']['speed']
+        longitudinal = vehicle_state['velocity'].get('longitudinal', vehicle_state['velocity'].get('vx', 0.0))
+        gear = (
+            vehicle_state.get('gear')
+            or (vehicle_state.get('transmission') or {}).get('gear')
+            or 'D'
+        )
 
         # Detect trailer from sensor data
         self._detect_trailer(sensor_data)
 
         # System only active if trailer is detected and reversing
-        is_reversing = current_speed < -0.5  # Negative speed = reversing
+        is_reversing = gear == 'R' or longitudinal < -0.5
         self.active = self.enabled and self.trailer_detected and is_reversing
 
         if not self.active:
@@ -302,9 +308,15 @@ class TrailerReverseGuidance:
             Dictionary with guidance status
         """
         current_speed = vehicle_state['velocity']['speed']
+        longitudinal = vehicle_state['velocity'].get('longitudinal', vehicle_state['velocity'].get('vx', 0.0))
+        gear = (
+            vehicle_state.get('gear')
+            or (vehicle_state.get('transmission') or {}).get('gear')
+            or 'D'
+        )
 
         # Only active when reversing
-        is_reversing = current_speed < -0.5
+        is_reversing = gear == 'R' or longitudinal < -0.5
         self.active = self.enabled and is_reversing and self.guidance_active
 
         if not self.active or not self.target_path:

--- a/ADAS_SIL_System/core/sensors/base_sensor.py
+++ b/ADAS_SIL_System/core/sensors/base_sensor.py
@@ -110,6 +110,15 @@ class BaseSensor(ABC):
         dy_sensor = dy_ego - self.position[1]
         dz_sensor = dz_ego - self.position[2]
 
+        # Apply sensor mount yaw so side/rear radars face correctly
+        sensor_yaw = float(self.orientation[2]) if len(self.orientation) > 2 else 0.0
+        if abs(sensor_yaw) > 1e-9:
+            cos_s = np.cos(sensor_yaw)
+            sin_s = np.sin(sensor_yaw)
+            dx_local = dx_sensor * cos_s + dy_sensor * sin_s
+            dy_local = -dx_sensor * sin_s + dy_sensor * cos_s
+            dx_sensor, dy_sensor = dx_local, dy_local
+
         # Calculate range and angles
         range_xy = np.sqrt(dx_sensor**2 + dy_sensor**2)
         total_range = np.sqrt(dx_sensor**2 + dy_sensor**2 + dz_sensor**2)

--- a/ADAS_SIL_System/core/sensors/radar.py
+++ b/ADAS_SIL_System/core/sensors/radar.py
@@ -137,9 +137,16 @@ class RadarSensor(BaseSensor):
         dy_ego = -dx * sin_yaw + dy * cos_yaw
 
         # Sensor frame (accounting for mounting position)
-        dx_sensor = dx_ego - self.position[0]
-        dy_sensor = dy_ego - self.position[1]
+        dx_mount = dx_ego - self.position[0]
+        dy_mount = dy_ego - self.position[1]
         dz_sensor = dz - ego_pos[2] - self.position[2]
+
+        # Rotate into sensor boresight frame for FOV-consistent angles
+        sensor_yaw = float(self.orientation[2]) if len(self.orientation) > 2 else 0.0
+        cos_s = np.cos(sensor_yaw)
+        sin_s = np.sin(sensor_yaw)
+        dx_sensor = dx_mount * cos_s + dy_mount * sin_s
+        dy_sensor = -dx_mount * sin_s + dy_mount * cos_s
 
         # Range calculation
         range_val = np.sqrt(dx_sensor**2 + dy_sensor**2 + dz_sensor**2)
@@ -149,9 +156,14 @@ class RadarSensor(BaseSensor):
         if weather_loss > 10.0:  # Too much attenuation
             return None
 
-        # Angles
-        azimuth = np.arctan2(dy_sensor, dx_sensor)
+        # Sensor-frame angles (for FOV diagnostics)
+        sensor_azimuth = np.arctan2(dy_sensor, dx_sensor)
         elevation = np.arctan2(dz_sensor, np.sqrt(dx_sensor**2 + dy_sensor**2))
+
+        # Vehicle-frame pose for ADAS features (BSD/ACC expect ego-forward frame)
+        # Use ego-frame offset from vehicle origin (not sensor mount)
+        vehicle_azimuth = np.arctan2(dy_ego, dx_ego)
+        vehicle_range = np.sqrt(dx_ego**2 + dy_ego**2)
 
         # Relative velocity (doppler)
         if is_static:
@@ -171,15 +183,21 @@ class RadarSensor(BaseSensor):
         else:
             radial_velocity = 0.0
 
-        # Create detection
+        # Create detection — azimuth/range in vehicle frame for ADAS consumers
         detection = {
             'sensor_id': self.sensor_id,
             'sensor_type': 'radar',
             'object_id': obj.get('id', -1),
             'timestamp': self.last_update_time,
-            'range': range_val,
-            'azimuth': azimuth,
+            'range': vehicle_range if vehicle_range > 0 else range_val,
+            'azimuth': vehicle_azimuth,
             'elevation': elevation,
+            'sensor_azimuth': sensor_azimuth,
+            'sensor_range': range_val,
+            'x': dx_ego,
+            'y': dy_ego,
+            'frame': 'vehicle',
+            'classification': obj.get('classification', 'vehicle'),
             'radial_velocity': radial_velocity,
             'rcs': rcs,  # Radar cross section
             'false_alarm': False

--- a/ADAS_SIL_System/core/vehicle_dynamics.py
+++ b/ADAS_SIL_System/core/vehicle_dynamics.py
@@ -96,6 +96,9 @@ class VehicleDynamics:
         self.brake = 0.0  # [0, 1]
         self.steering_angle = 0.0  # rad
 
+        # Transmission / drive direction (needed for reverse, SVC, trailer)
+        self.gear = 'D'  # 'P', 'R', 'N', 'D'
+
         logger.info("Vehicle state reset")
 
     def set_state(self, x: float, y: float, yaw: float, vx: float, vy: float = 0.0):
@@ -128,6 +131,22 @@ class VehicleDynamics:
         self.brake = np.clip(brake, 0.0, 1.0)
         self.steering_angle = np.clip(steering_angle, -self.max_steering_angle, self.max_steering_angle)
 
+    def set_gear(self, gear: str):
+        """Set transmission gear: P, R, N, or D."""
+        gear = str(gear).upper()
+        if gear not in ('P', 'R', 'N', 'D'):
+            raise ValueError(f"Invalid gear: {gear}")
+        self.gear = gear
+        # When shifting to reverse while nearly stopped, allow reverse kinematics
+        if gear == 'R' and abs(self.vx) < 0.5:
+            self.vx = min(self.vx, 0.0)
+        if gear == 'D' and abs(self.vx) < 0.5:
+            self.vx = max(self.vx, 0.0)
+        if gear == 'P':
+            self.vx = 0.0
+            self.vy = 0.0
+            self.yaw_rate = 0.0
+
     def update(self, dt: float):
         """
         Update vehicle state using bicycle model dynamics.
@@ -135,7 +154,16 @@ class VehicleDynamics:
         Args:
             dt: Time step (s)
         """
-        # Calculate total velocity
+        # Park lock
+        if self.gear == 'P':
+            self.vx = 0.0
+            self.vy = 0.0
+            self.yaw_rate = 0.0
+            self.ax = 0.0
+            self.ay = 0.0
+            return
+
+        # Calculate total velocity magnitude
         v = np.sqrt(self.vx**2 + self.vy**2)
 
         # Longitudinal dynamics
@@ -160,34 +188,51 @@ class VehicleDynamics:
             v: Total velocity (m/s)
         """
         # Calculate forces
-        # Engine force (simplified)
-        if self.throttle > 0:
-            F_drive = self.throttle * self.mass * self.max_acceleration
+        # Drive force direction depends on gear (reverse support for trailer/SVC)
+        drive_sign = -1.0 if self.gear == 'R' else 1.0
+        if self.gear == 'N':
+            drive_sign = 0.0
+
+        if self.throttle > 0 and drive_sign != 0.0:
+            F_drive = drive_sign * self.throttle * self.mass * self.max_acceleration
         else:
             F_drive = 0.0
 
-        # Braking force
+        # Braking force opposes current motion (and holds when stopped)
         if self.brake > 0:
-            F_brake = self.brake * self.mass * abs(self.max_deceleration)
+            if abs(self.vx) > 0.05:
+                brake_sign = -np.sign(self.vx)
+            else:
+                brake_sign = -drive_sign if drive_sign != 0 else 0.0
+            F_brake = brake_sign * self.brake * self.mass * abs(self.max_deceleration)
         else:
             F_brake = 0.0
 
-        # Aerodynamic drag
-        F_drag = 0.5 * self.air_density * self.drag_coefficient * self.frontal_area * v**2
+        # Aerodynamic drag opposes motion
+        drag_sign = -np.sign(self.vx) if abs(self.vx) > 0.01 else 0.0
+        F_drag = drag_sign * 0.5 * self.air_density * self.drag_coefficient * self.frontal_area * v**2
 
-        # Rolling resistance (simplified)
-        F_rolling = 0.015 * self.mass * 9.81
+        # Rolling resistance opposes motion
+        roll_sign = -np.sign(self.vx) if abs(self.vx) > 0.01 else 0.0
+        F_rolling = roll_sign * 0.015 * self.mass * 9.81
 
         # Net longitudinal force
-        F_x = F_drive - F_brake - F_drag - F_rolling
+        F_x = F_drive + F_brake + F_drag + F_rolling
 
         # Longitudinal acceleration
         self.ax = F_x / self.mass
 
-        # Update longitudinal velocity
+        # Update longitudinal velocity — allow reverse when in R
         self.vx += self.ax * dt
-        self.vx = max(0.0, self.vx)  # Prevent negative velocity
-
+        if self.gear == 'R':
+            # Cap reverse speed magnitude
+            self.vx = np.clip(self.vx, -15.0, 0.5)
+        elif self.gear == 'D':
+            self.vx = max(0.0, self.vx)
+        else:
+            # Neutral — allow coasting either way but damp near zero
+            if abs(self.vx) < 0.02:
+                self.vx = 0.0
     def _update_lateral(self, dt: float, v: float):
         """
         Update lateral dynamics using bicycle model.
@@ -196,8 +241,8 @@ class VehicleDynamics:
             dt: Time step (s)
             v: Total velocity (m/s)
         """
-        # Slip angles at front and rear axles
-        if v > 0.1:
+        # Slip angles at front and rear axles (use signed longitudinal velocity)
+        if abs(self.vx) > 0.1:
             alpha_f = self.steering_angle - np.arctan2(
                 self.vy + self.yaw_rate * self.cg_to_front, self.vx
             )
@@ -262,7 +307,9 @@ class VehicleDynamics:
                 'vx': self.vx,
                 'vy': self.vy,
                 'vz': 0.0,
-                'speed': np.sqrt(self.vx**2 + self.vy**2)
+                'speed': np.sqrt(self.vx**2 + self.vy**2),
+                # Signed longitudinal speed for reverse-aware features
+                'longitudinal': self.vx,
             },
             'acceleration': {'ax': self.ax, 'ay': self.ay, 'az': 0.0},
             'angular_velocity': {'roll_rate': 0.0, 'pitch_rate': 0.0, 'yaw_rate': self.yaw_rate},
@@ -271,6 +318,8 @@ class VehicleDynamics:
                 'brake': self.brake,
                 'steering_angle': self.steering_angle
             },
+            'transmission': {'gear': self.gear},
+            'gear': self.gear,
             'dimensions': {
                 'length': self.length,
                 'width': self.width,

--- a/ADAS_SIL_System/simulator.py
+++ b/ADAS_SIL_System/simulator.py
@@ -98,6 +98,31 @@ class ADASSILSimulator:
             radar_config.setdefault('fov_horizontal', 20.0)
             self.sensors['front_radar'] = RadarSensor('front_radar', radar_config)
 
+        # Side / rear radars for BSD coverage
+        if sensors_config.get('left_radar', {}).get('enabled', True):
+            left_cfg = dict(sensors_config.get('left_radar', {}))
+            left_cfg.setdefault('position', [0.0, 0.9, 0.5])
+            left_cfg.setdefault('orientation', [0.0, 0.0, np.deg2rad(90)])
+            left_cfg.setdefault('max_range', 40.0)
+            left_cfg.setdefault('fov_horizontal', 120.0)
+            self.sensors['left_radar'] = RadarSensor('left_radar', left_cfg)
+
+        if sensors_config.get('right_radar', {}).get('enabled', True):
+            right_cfg = dict(sensors_config.get('right_radar', {}))
+            right_cfg.setdefault('position', [0.0, -0.9, 0.5])
+            right_cfg.setdefault('orientation', [0.0, 0.0, np.deg2rad(-90)])
+            right_cfg.setdefault('max_range', 40.0)
+            right_cfg.setdefault('fov_horizontal', 120.0)
+            self.sensors['right_radar'] = RadarSensor('right_radar', right_cfg)
+
+        if sensors_config.get('rear_radar', {}).get('enabled', True):
+            rear_cfg = dict(sensors_config.get('rear_radar', {}))
+            rear_cfg.setdefault('position', [-2.0, 0.0, 0.5])
+            rear_cfg.setdefault('orientation', [0.0, 0.0, np.pi])
+            rear_cfg.setdefault('max_range', 60.0)
+            rear_cfg.setdefault('fov_horizontal', 80.0)
+            self.sensors['rear_radar'] = RadarSensor('rear_radar', rear_cfg)
+
         # Front camera
         if sensors_config.get('front_camera', {}).get('enabled', True):
             camera_config = sensors_config.get('front_camera', {})
@@ -168,9 +193,22 @@ class ADASSILSimulator:
         # Reset simulation
         self.reset()
 
-        # Set initial vehicle state
+        # Set initial vehicle state (engine format)
         initial_conditions = scenario.get('initial_conditions', {})
         ego_init = initial_conditions.get('ego_vehicle', {})
+
+        # Also accept MIL-style vehicle_config
+        vehicle_config = scenario.get('vehicle_config', {})
+        if not ego_init and vehicle_config:
+            pos = vehicle_config.get('initial_position', [0.0, 0.0])
+            if isinstance(pos, dict):
+                pos = [pos.get('x', 0.0), pos.get('y', 0.0)]
+            ego_init = {
+                'position': list(pos) + ([0.0] if len(pos) < 3 else []),
+                'velocity': float(vehicle_config.get('initial_speed', 0.0)),
+                'yaw': float(vehicle_config.get('initial_yaw', 0.0)),
+                'gear': vehicle_config.get('gear', 'R' if vehicle_config.get('has_trailer') else 'D'),
+            }
 
         if 'position' in ego_init:
             pos = ego_init['position']
@@ -178,8 +216,18 @@ class ADASSILSimulator:
             yaw = ego_init.get('yaw', 0.0)
             self.vehicle.set_state(pos[0], pos[1], yaw, vel)
 
+        if 'gear' in ego_init:
+            self.vehicle.set_gear(ego_init['gear'])
+        elif vehicle_config.get('has_trailer'):
+            # Trailer assist demos typically reverse
+            pass  # keep D unless scenario sets R via events
+
         # Set environment
         self.environment.update(copy.deepcopy(scenario.get('environment', {})))
+        # Normalize environment vehicles list if missing
+        self.environment.setdefault('vehicles', [])
+        self.environment.setdefault('traffic_signs', [])
+        self.environment.setdefault('lanes', [])
 
         # Load scenario events
         self.scenario_events = sorted(
@@ -188,7 +236,49 @@ class ADASSILSimulator:
         )
         self.next_event_index = 0
 
+        # Activate features that were configured enabled (ACC/TSR honor runtime enable)
+        self._activate_configured_features()
+
         logger.info("Scenario loaded successfully")
+
+    def _activate_configured_features(self):
+        """Enable ADAS features whose config requested enabled=True."""
+        vehicle_state = self.vehicle.get_state()
+        speed = vehicle_state['velocity']['speed']
+        longitudinal = vehicle_state['velocity'].get('longitudinal', speed)
+
+        if 'acc' in self.adas_features:
+            acc = self.adas_features['acc']
+            if getattr(acc, 'enabled', False) or self.config.get('adas', {}).get('acc', {}).get('enabled', True):
+                # Bootstrap ACC with current (or set) speed so control loop runs
+                enable_speed = speed if speed >= getattr(acc, 'min_speed', 0) else max(speed, acc.set_speed)
+                acc.enable(enable_speed if enable_speed > 0 else acc.set_speed)
+
+        if 'tsr' in self.adas_features:
+            tsr = self.adas_features['tsr']
+            if not tsr.enabled:
+                tsr.enable()
+
+        if 'bsd' in self.adas_features:
+            self.adas_features['bsd'].enable()
+
+        if 'trailer_assistance' in self.adas_features:
+            assist = self.adas_features['trailer_assistance']
+            if hasattr(assist, 'enable'):
+                assist.enable()
+            # Trailer scenarios typically start in reverse
+            ego_init_gear = (
+                (self.config.get('vehicle') or {}).get('gear')
+            )
+            # Scenario may request reverse via initial conditions elsewhere; default keep D
+
+        if 'parking' in self.adas_features:
+            parking = self.adas_features['parking']
+            if hasattr(parking, 'enable') and not getattr(parking, 'enabled', True):
+                parking.enable()
+
+        # Apply gear from scenario initial conditions if present on environment/meta
+        _ = longitudinal  # reserved for future reverse bootstrap
 
     def reset(self):
         """Reset simulation to initial state."""
@@ -256,13 +346,98 @@ class ADASSILSimulator:
             self.next_event_index += 1
 
     def _apply_scenario_event(self, event: Dict):
-        """Apply a single scenario event to an environment actor."""
+        """Apply a single scenario event to an environment actor or ego vehicle."""
+        event_type = event.get('type')
+
+        # Ego gear / motion helpers used by parking & trailer scenarios
+        if event_type == 'ego_gear':
+            gear = event.get('gear', 'D')
+            self.vehicle.set_gear(gear)
+            return
+        if event_type == 'ego_controls':
+            self.vehicle.set_controls(
+                event.get('throttle', 0.0),
+                event.get('brake', 0.0),
+                event.get('steering_angle', 0.0),
+            )
+            return
+
+        # Spawn / approach helper for BSD scenarios (MIL-style event)
+        if event_type == 'vehicle_approaching':
+            params = event.get('parameters') or event.get('params') or event
+            side = str(params.get('side', 'left')).lower()
+            speed = float(params.get('speed', params.get('approach_speed', 20.0)))
+            distance = float(params.get('initial_distance', 40.0))
+            # Place adjacent-lane traffic relative to ego
+            ego = self.vehicle.get_state()
+            ex = ego['position']['x']
+            ey = ego['position']['y']
+            yaw = ego['orientation']['yaw']
+            # Lateral offset ~ one lane (~3.5m); longitudinal behind for blind spot
+            if side == 'left':
+                lat = 3.5
+                long_offset = -8.0
+            elif side == 'right':
+                lat = -3.5
+                long_offset = -8.0
+            else:  # rear
+                lat = 0.0
+                long_offset = -min(distance, 25.0)
+
+            cos_y, sin_y = np.cos(yaw), np.sin(yaw)
+            # Body frame: +x forward, +y left
+            wx = ex + long_offset * cos_y - lat * sin_y
+            wy = ey + long_offset * sin_y + lat * cos_y
+            # Match ego forward speed so relative motion stays in zone briefly
+            ego_speed = ego['velocity'].get('longitudinal', ego['velocity']['speed'])
+            vx_world = ego_speed * cos_y  # approximate; actors only use vx along world +x today
+            # Prefer actor motion along ego heading by storing both vx/vy
+            vehicles = self.environment.setdefault('vehicles', [])
+            vehicles.append({
+                'id': params.get('vehicle_id', event.get('vehicle_id', 9000 + len(vehicles))),
+                'position': {'x': wx, 'y': wy, 'z': 0.0},
+                'velocity': {
+                    'vx': float(speed if abs(yaw) < 0.2 else speed * cos_y),
+                    'vy': float(0.0 if abs(yaw) < 0.2 else speed * sin_y),
+                    'vz': 0.0,
+                },
+                'dimensions': params.get('dimensions', {'length': 4.5, 'width': 1.8, 'height': 1.5}),
+                'classification': 'vehicle',
+            })
+            return
+
+        # Ignore MIL validation / feature_command here (handled by MIL runner)
+        if event_type in ('validation', 'feature_command', 'environment_setup', 'vehicle_motion'):
+            # Best-effort vehicle_motion for ego
+            if event_type == 'vehicle_motion':
+                params = event.get('parameters') or event.get('params') or {}
+                if 'gear' in params:
+                    self.vehicle.set_gear(params['gear'])
+                if 'steering_angle' in params:
+                    self.vehicle.set_controls(
+                        self.vehicle.throttle,
+                        self.vehicle.brake,
+                        float(params['steering_angle']),
+                    )
+                if 'speed_target' in params:
+                    target = float(params['speed_target'])
+                    # Approximate by setting vx toward target
+                    self.vehicle.vx = target
+                if 'acceleration' in params and event.get('vehicle_id') is not None:
+                    vehicle = self._find_vehicle(event.get('vehicle_id'))
+                    if vehicle is not None:
+                        vehicle['acceleration'] = float(params['acceleration'])
+                        duration = params.get('duration')
+                        vehicle['acceleration_end_time'] = (
+                            self.current_time + duration if duration is not None else None
+                        )
+            return
+
         vehicle = self._find_vehicle(event.get('vehicle_id'))
         if vehicle is None:
             logger.warning(f"Scenario event target not found: {event}")
             return
 
-        event_type = event.get('type')
         if event_type == 'vehicle_acceleration':
             vehicle['acceleration'] = event.get('acceleration', 0.0)
             duration = event.get('duration')
@@ -304,6 +479,9 @@ class ADASSILSimulator:
         """
         Compute vehicle control inputs based on ADAS commands.
 
+        Priority: AEB > parking > trailer reverse > ACC longitudinal.
+        Lateral: parking / trailer steering when active.
+
         Args:
             adas_status: Status from all ADAS features
             vehicle_state: Current vehicle state
@@ -316,17 +494,56 @@ class ADASSILSimulator:
         steering = 0.0
 
         # AEB has highest priority
-        if 'aeb' in adas_status and adas_status['aeb']['braking_active']:
-            brake = adas_status['aeb']['braking_level']
+        if 'aeb' in adas_status and adas_status['aeb'].get('braking_active'):
+            brake = adas_status['aeb'].get('braking_level', 1.0)
+            return throttle, brake, steering
+
+        # Autonomous parking controls (when maneuver active)
+        parking = adas_status.get('parking') or {}
+        if parking.get('active'):
+            target_speed = float(parking.get('target_speed', 0.0))
+            current_speed = float(vehicle_state['velocity'].get('speed', 0.0))
+            steering = float(parking.get('target_steering_angle', 0.0))
+            if parking.get('brake_active'):
+                brake = 0.6
+            elif target_speed > current_speed + 0.2:
+                throttle = min((target_speed - current_speed) / 2.0, 0.4)
+            elif target_speed < current_speed - 0.2:
+                brake = min((current_speed - target_speed) / 3.0, 0.5)
+            return throttle, brake, steering
+
+        # Trailer reverse steering correction (status reports degrees for TrailerAssistance)
+        trailer = adas_status.get('trailer_assistance') or {}
+        trailer_rev = adas_status.get('trailer_reverse') or {}
+        if trailer.get('active') or trailer_rev.get('active'):
+            if trailer.get('active'):
+                steering = np.deg2rad(float(trailer.get('steering_correction', 0.0)))
+            else:
+                # TrailerReverseGuidance may expose steering differently
+                steering = float(trailer_rev.get('steering_angle', trailer_rev.get('steering_correction', 0.0)))
+                if abs(steering) > np.pi:
+                    steering = np.deg2rad(steering)
+            gear = vehicle_state.get('gear') or (vehicle_state.get('transmission') or {}).get('gear')
+            if gear == 'R' and vehicle_state['velocity'].get('speed', 0) < 1.0:
+                throttle = 0.15
             return throttle, brake, steering
 
         # ACC controls throttle/brake
-        if 'acc' in adas_status and adas_status['acc']['active']:
-            target_accel = adas_status['acc']['target_acceleration']
+        if 'acc' in adas_status and adas_status['acc'].get('active'):
+            target_accel = adas_status['acc'].get('target_acceleration', 0.0)
             if target_accel > 0:
                 throttle = min(target_accel / 2.0, 1.0)
             else:
                 brake = min(abs(target_accel) / 8.0, 1.0)
+
+        # Mild LDW corrective steer (if warning active) — optional assist
+        ldw = adas_status.get('ldw') or {}
+        if ldw.get('warning_active') and steering == 0.0:
+            side = ldw.get('warning_side')
+            if side == 'left':
+                steering = -0.02
+            elif side == 'right':
+                steering = 0.02
 
         return throttle, brake, steering
 
@@ -425,15 +642,78 @@ class ADASSILSimulator:
                         'event': 'emergency_braking',
                         'level': status.get('braking_level')
                     })
+                elif feature_name == 'acc' and status.get('active'):
+                    # Sparse ACC events — only when lead vehicle present or significant accel cmd
+                    if status.get('lead_vehicle_detected') or abs(status.get('target_acceleration', 0)) > 0.5:
+                        adas_events.append({
+                            'time': entry['time'],
+                            'feature': 'ACC',
+                            'event': 'acc_active',
+                            'set_speed': status.get('set_speed'),
+                            'lead_distance': status.get('lead_vehicle_distance'),
+                        })
+                elif feature_name == 'bsd' and status.get('warning_active'):
+                    adas_events.append({
+                        'time': entry['time'],
+                        'feature': 'BSD',
+                        'event': 'blind_spot_warning',
+                        'side': status.get('warning_side'),
+                        'left_occupied': status.get('left_occupied'),
+                        'right_occupied': status.get('right_occupied'),
+                    })
+                elif feature_name == 'tsr' and (
+                    status.get('active') or status.get('current_speed_limit') is not None
+                ):
+                    adas_events.append({
+                        'time': entry['time'],
+                        'feature': 'TSR',
+                        'event': 'traffic_sign_detected',
+                        'speed_limit_kmh': status.get('speed_limit_kmh') or status.get('current_speed_limit'),
+                        'signs_detected': status.get('signs_detected', 0),
+                    })
+                elif feature_name == 'parking' and status.get('active'):
+                    adas_events.append({
+                        'time': entry['time'],
+                        'feature': 'PARKING',
+                        'event': 'parking_maneuver',
+                        'stage': status.get('stage'),
+                        'progress': status.get('progress'),
+                    })
+                elif feature_name in ('trailer_assistance', 'trailer_reverse') and status.get('active'):
+                    adas_events.append({
+                        'time': entry['time'],
+                        'feature': 'TRAILER',
+                        'event': 'trailer_guidance',
+                        'warning': status.get('warning_active', False),
+                    })
+
+        # Deduplicate high-frequency events (keep ~2 Hz max per feature type)
+        adas_events = self._downsample_events(adas_events, min_interval=0.5)
 
         results = {
             'duration': self.current_time,
             'steps': len(self.log_data),
             'adas_events': adas_events,
-            'log_data': self.log_data
+            'log_data': self.log_data,
+            'final_adas': self.log_data[-1]['adas'] if self.log_data else {},
+            'final_vehicle': self.log_data[-1]['vehicle'] if self.log_data else {},
         }
 
         return results
+
+    def _downsample_events(self, events: List[Dict], min_interval: float = 0.5) -> List[Dict]:
+        """Keep event density manageable for API responses."""
+        last_by_key = {}
+        filtered = []
+        for event in events:
+            key = (event.get('feature'), event.get('event'), event.get('side'))
+            t = event.get('time', 0.0)
+            prev = last_by_key.get(key)
+            if prev is not None and (t - prev) < min_interval:
+                continue
+            last_by_key[key] = t
+            filtered.append(event)
+        return filtered
 
     def get_state(self) -> Dict:
         """

--- a/ADAS_SIL_System/tests/test_bugfixes.py
+++ b/ADAS_SIL_System/tests/test_bugfixes.py
@@ -1,0 +1,131 @@
+"""Regression tests for critical ADAS / infotainment bugfixes."""
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ADAS_SIL_System.simulator import ADASSILSimulator
+from core.vehicle_dynamics import VehicleDynamics
+from core.adas_features.acc import AdaptiveCruiseControl
+from core.adas_features.traffic_sign_recognition import TrafficSignRecognition
+from core.adas_features.blind_spot_detection import BlindSpotDetection
+
+
+class TestFeatureEnableFromConfig:
+    def test_acc_honors_enabled_config(self):
+        acc = AdaptiveCruiseControl({"enabled": True, "set_speed": 25.0})
+        assert acc.enabled is True
+
+    def test_tsr_honors_enabled_config(self):
+        tsr = TrafficSignRecognition({"enabled": True})
+        assert tsr.enabled is True
+
+    def test_simulator_activates_acc_after_load(self):
+        sim = ADASSILSimulator({"adas": {"acc": {"enabled": True}, "aeb": {"enabled": True}}})
+        sim.load_scenario({
+            "name": "acc_bootstrap",
+            "initial_conditions": {
+                "ego_vehicle": {"position": [0, 0], "velocity": 30.0, "yaw": 0.0}
+            },
+            "environment": {"vehicles": []},
+            "events": [],
+        })
+        assert sim.adas_features["acc"].enabled is True
+
+
+class TestTSRCameraSchema:
+    def test_accepts_camera_sign_type_and_value(self):
+        tsr = TrafficSignRecognition({"enabled": True, "min_confidence": 0.5})
+        tsr.enable()
+        vehicle_state = {
+            "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+            "velocity": {"speed": 10.0, "vx": 10.0, "vy": 0.0},
+        }
+        detections = [{
+            "sensor_type": "camera",
+            "detection_type": "traffic_sign",
+            "sign_type": "speed_limit",
+            "sign_value": 50,
+            "range": 40.0,
+            "confidence": 0.95,
+        }]
+        status = tsr.update(vehicle_state, detections, 1.0, 0.01)
+        assert status["current_speed_limit"] == 50.0
+        assert status["signs_detected"] >= 1
+
+    def test_does_not_crash_on_dict_position(self):
+        tsr = TrafficSignRecognition({"enabled": True})
+        tsr.enable()
+        vehicle_state = {"position": {"x": 1.0, "y": 2.0}, "velocity": {"speed": 5.0}}
+        detections = [{
+            "sensor_type": "camera",
+            "sign_class": "speed_60",
+            "confidence": 0.99,
+            "distance": 30.0,
+        }]
+        status = tsr.update(vehicle_state, detections, 0.5, 0.01)
+        assert status["enabled"] is True
+
+
+class TestReverseGear:
+    def test_vehicle_can_reverse_in_gear_r(self):
+        vehicle = VehicleDynamics()
+        vehicle.set_gear("R")
+        vehicle.set_controls(throttle=0.5, brake=0.0, steering_angle=0.0)
+        for _ in range(20):
+            vehicle.update(0.05)
+        assert vehicle.vx < 0.0
+        state = vehicle.get_state()
+        assert state["gear"] == "R"
+        assert state["velocity"]["longitudinal"] < 0.0
+
+
+class TestBSDRadarPolar:
+    def test_bsd_uses_range_azimuth_without_classification(self):
+        bsd = BlindSpotDetection()
+        bsd.enable()
+        vehicle_state = {
+            "position": {"x": 0.0, "y": 0.0},
+            "orientation": {"yaw": 0.0},
+            "velocity": {"speed": 20.0},
+        }
+        # Left blind-spot polar detection (vehicle frame; left = negative azimuth in this model)
+        detections = [{
+            "sensor_type": "radar",
+            "object_id": 1,
+            "range": 5.0,
+            "azimuth": math.radians(-90),
+            "false_alarm": False,
+        }]
+        status = bsd.update(vehicle_state, detections, 1.0, 0.01)
+        assert status["left_occupied"] is True
+        assert status["warning_active"] is True
+
+
+class TestControlArbitration:
+    def test_acc_applies_throttle_when_enabled(self):
+        sim = ADASSILSimulator({
+            "dt": 0.05,
+            "adas": {
+                "acc": {"enabled": True, "set_speed": 25.0},
+                "aeb": {"enabled": False},
+                "ldw": {"enabled": False},
+            },
+        })
+        # Disable side radars noise path isn't needed; keep defaults
+        sim.load_scenario({
+            "name": "acc_cruise",
+            "initial_conditions": {
+                "ego_vehicle": {"position": [0, 0], "velocity": 10.0, "yaw": 0.0}
+            },
+            "environment": {"vehicles": []},
+            "events": [],
+        })
+        for _ in range(80):
+            sim.step()
+        assert sim.vehicle.vx > 12.0

--- a/README.md
+++ b/README.md
@@ -112,8 +112,14 @@ cd mobile-app && npx expo start
 │   └── src/                   # Components, pages, visuals
 ├── mobile-app/                # React Native / Expo Android app
 │   └── src/                   # Screens, components
+├── docs/                      # Design review & feedback documents
+│   └── REVIEW_AND_FEEDBACK.md # Bug audit, AAOS gaps, roadmap
 └── .github/workflows/         # CI/CD pipelines
 ```
+
+## Design review
+
+See [`docs/REVIEW_AND_FEEDBACK.md`](docs/REVIEW_AND_FEEDBACK.md) for the latest engineering review: fixed bugs, Android Automotive compatibility gaps, and recommended next steps.
 
 ## Deployments
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -445,7 +445,12 @@ async def list_scenarios():
 @app.post("/simulate")
 async def run_simulation(config: SimulationConfig):
     """Run a full simulation and return results with visual data."""
-    scenario_data = _load_scenario_data(config.scenario)
+    try:
+        scenario_data = _load_scenario_data(config.scenario)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to load scenario: {exc}") from exc
 
     adas_config = {
         "dt": config.dt,
@@ -456,47 +461,59 @@ async def run_simulation(config: SimulationConfig):
             "bsd": {"enabled": True},
             "tsr": {"enabled": True},
             "surround_view": {"enabled": True},
+            "parking": {"enabled": True},
+            "trailer": {"enabled": True},
         },
     }
 
-    sim = ADASSILSimulator(adas_config)
-    sim.load_scenario(scenario_data)
+    try:
+        sim = ADASSILSimulator(adas_config)
+        sim.load_scenario(scenario_data)
 
-    steps = int(config.duration / config.dt)
-    vehicle_trace = []
-    camera_frames = []
+        steps = int(config.duration / config.dt)
+        vehicle_trace = []
+        camera_frames = []
 
-    for i in range(steps):
-        sim.step()
-        if i % 10 == 0:
-            state = sim.get_state()
-            vehicle_trace.append({
-                "time": state["time"],
-                "x": state["vehicle"]["position"]["x"],
-                "y": state["vehicle"]["position"]["y"],
-                "speed_kmh": state["vehicle"]["velocity"]["speed"] * 3.6,
-                "yaw": state["vehicle"]["orientation"]["yaw"],
-                "throttle": state["vehicle"]["controls"]["throttle"],
-                "brake": state["vehicle"]["controls"]["brake"],
-                "steering": state["vehicle"]["controls"]["steering_angle"],
-            })
-            camera_frames.append({
-                "time": state["time"],
-                "sensors": list(state["sensors"].keys()),
-                "detections_count": len(sim.sensors.get("front_camera", type("", (), {"detections": []})()).detections) if "front_camera" in sim.sensors else 0,
-            })
+        for i in range(steps):
+            sim.step()
+            if i % 10 == 0:
+                state = sim.get_state()
+                vehicle_trace.append({
+                    "time": state["time"],
+                    "x": state["vehicle"]["position"]["x"],
+                    "y": state["vehicle"]["position"]["y"],
+                    "speed_kmh": state["vehicle"]["velocity"]["speed"] * 3.6,
+                    "yaw": state["vehicle"]["orientation"]["yaw"],
+                    "throttle": state["vehicle"]["controls"]["throttle"],
+                    "brake": state["vehicle"]["controls"]["brake"],
+                    "steering": state["vehicle"]["controls"]["steering_angle"],
+                    "gear": state["vehicle"].get("gear", "D"),
+                })
+                front_cam = sim.sensors.get("front_camera")
+                camera_frames.append({
+                    "time": state["time"],
+                    "sensors": list(state["sensors"].keys()),
+                    "detections_count": len(getattr(front_cam, "detections", []) or []),
+                })
 
-    results = sim.get_results()
+        results = sim.get_results()
+        radio_display = _generate_radio_display_state(results, vehicle_trace)
 
-    return {
-        "scenario": config.scenario,
-        "duration": results["duration"],
-        "steps": results["steps"],
-        "adas_events": results["adas_events"][:50],
-        "vehicle_trace": vehicle_trace,
-        "camera_frames": camera_frames,
-        "radio_display": _generate_radio_display_state(results),
-    }
+        return {
+            "scenario": config.scenario,
+            "duration": results["duration"],
+            "steps": results["steps"],
+            "adas_events": results["adas_events"][:50],
+            "vehicle_trace": vehicle_trace,
+            "camera_frames": camera_frames,
+            "radio_display": radio_display,
+            # Alias for clients that expect test-case naming
+            "radio_display_state": radio_display,
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Simulation failed: {exc}") from exc
 
 
 @app.post("/test-cases/run")
@@ -518,53 +535,81 @@ async def run_test_case(req: TestCaseRequest) -> TestCaseResult:
             adas_features = list(case.get("adas_features", []))
         duration = max(duration, float(case.get("default_duration", duration)))
 
-    scenario_data = _load_scenario_data(scenario_name)
+    try:
+        scenario_data = _load_scenario_data(scenario_name)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to load scenario: {exc}") from exc
+
+    # Map catalog aliases to simulator feature keys
+    feature_map = {
+        "trailer": "trailer",
+        "surround_view": "surround_view",
+        "parking": "parking",
+        "tsr": "tsr",
+        "bsd": "bsd",
+        "acc": "acc",
+        "aeb": "aeb",
+        "ldw": "ldw",
+    }
+    adas_enabled = {}
+    for feat in adas_features:
+        key = feature_map.get(feat, feat)
+        adas_enabled[key] = {"enabled": True}
 
     adas_config = {
         "dt": 0.01,
-        "adas": {feat: {"enabled": True} for feat in adas_features},
+        "adas": adas_enabled,
     }
 
-    sim = ADASSILSimulator(adas_config)
-    sim.load_scenario(scenario_data)
+    try:
+        sim = ADASSILSimulator(adas_config)
+        sim.load_scenario(scenario_data)
 
-    steps = int(duration / 0.01)
-    vehicle_trace = []
-    camera_frames = []
+        steps = int(duration / 0.01)
+        vehicle_trace = []
+        camera_frames = []
 
-    for i in range(steps):
-        sim.step()
-        if i % 50 == 0:
-            state = sim.get_state()
-            vehicle_trace.append({
-                "time": state["time"],
-                "x": state["vehicle"]["position"]["x"],
-                "y": state["vehicle"]["position"]["y"],
-                "speed_kmh": state["vehicle"]["velocity"]["speed"] * 3.6,
-                "yaw": state["vehicle"]["orientation"]["yaw"],
-                "throttle": state["vehicle"]["controls"]["throttle"],
-                "brake": state["vehicle"]["controls"]["brake"],
-            })
-            camera_frames.append({
-                "time": state["time"],
-                "active_cameras": list(state["sensors"].keys()),
-            })
+        for i in range(steps):
+            sim.step()
+            if i % 50 == 0:
+                state = sim.get_state()
+                vehicle_trace.append({
+                    "time": state["time"],
+                    "x": state["vehicle"]["position"]["x"],
+                    "y": state["vehicle"]["position"]["y"],
+                    "speed_kmh": state["vehicle"]["velocity"]["speed"] * 3.6,
+                    "yaw": state["vehicle"]["orientation"]["yaw"],
+                    "throttle": state["vehicle"]["controls"]["throttle"],
+                    "brake": state["vehicle"]["controls"]["brake"],
+                    "gear": state["vehicle"].get("gear", "D"),
+                })
+                camera_frames.append({
+                    "time": state["time"],
+                    "active_cameras": list(state["sensors"].keys()),
+                })
 
-    results = sim.get_results()
-    validation = _evaluate_test_case(case, duration, results, vehicle_trace)
+        results = sim.get_results()
+        validation = _evaluate_test_case(case, duration, results, vehicle_trace)
+        radio_state = _generate_radio_display_state(results, vehicle_trace)
 
-    return TestCaseResult(
-        test_id=req.test_id,
-        scenario=scenario_name,
-        status=validation["status"],
-        duration=results["duration"],
-        steps=results["steps"],
-        adas_events=results["adas_events"][:20],
-        vehicle_trace=vehicle_trace,
-        radio_display_state=_generate_radio_display_state(results),
-        camera_frames=camera_frames,
-        validation=validation,
-    )
+        return TestCaseResult(
+            test_id=req.test_id,
+            scenario=scenario_name,
+            status=validation["status"],
+            duration=results["duration"],
+            steps=results["steps"],
+            adas_events=results["adas_events"][:20],
+            vehicle_trace=vehicle_trace,
+            radio_display_state=radio_state,
+            camera_frames=camera_frames,
+            validation=validation,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Test case execution failed: {exc}") from exc
 
 
 @app.get("/test-cases")
@@ -628,26 +673,69 @@ async def get_camera_info():
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _generate_radio_display_state(results: dict) -> dict:
-    """Generate simulated Radio Display ECU state from results."""
+def _generate_radio_display_state(results: dict, vehicle_trace: list | None = None) -> dict:
+    """Generate Radio Display ECU state from simulation results."""
     events = results.get("adas_events", [])
     warnings = [e for e in events if "warning" in e.get("event", "")]
     braking = [e for e in events if "braking" in e.get("event", "")]
 
+    # Speed from last trace sample or final vehicle state
+    current_speed_kmh = 0.0
+    if vehicle_trace:
+        current_speed_kmh = float(vehicle_trace[-1].get("speed_kmh", 0.0))
+    else:
+        final_vehicle = results.get("final_vehicle") or {}
+        velocity = final_vehicle.get("velocity") or {}
+        current_speed_kmh = float(velocity.get("speed", 0.0)) * 3.6
+
+    final_adas = results.get("final_adas") or {}
+
+    # Prefer live final ADAS status; fall back to event history
+    acc_status = final_adas.get("acc") or {}
+    bsd_status = final_adas.get("bsd") or {}
+    tsr_status = final_adas.get("tsr") or {}
+    ldw_status = final_adas.get("ldw") or {}
+    aeb_status = final_adas.get("aeb") or {}
+    parking_status = final_adas.get("parking") or {}
+    svc_status = final_adas.get("surround_view") or {}
+
+    bsd_left = bool(bsd_status.get("left_occupied")) or any(
+        e.get("feature") == "BSD" and e.get("side") == "left" for e in events
+    )
+    bsd_right = bool(bsd_status.get("right_occupied")) or any(
+        e.get("feature") == "BSD" and e.get("side") == "right" for e in events
+    )
+    tsr_limit = tsr_status.get("speed_limit_kmh") or tsr_status.get("current_speed_limit")
+    tsr_detected = tsr_limit is not None or any(e.get("feature") == "TSR" for e in events)
+
+    camera_view = "front"
+    if svc_status.get("current_view"):
+        camera_view = str(svc_status.get("current_view")).lower()
+    elif parking_status.get("active"):
+        camera_view = "surround"
+
     return {
         "speed_display": {
-            "current_speed_kmh": 0,
+            "current_speed_kmh": round(current_speed_kmh, 1),
             "unit": "km/h",
+            "speed_limit_kmh": tsr_limit,
         },
         "adas_icons": {
-            "ldw_active": any(e["feature"] == "LDW" for e in events),
-            "acc_active": True,
-            "aeb_warning": len(braking) > 0,
-            "bsd_left": False,
-            "bsd_right": False,
-            "tsr_detected": False,
+            "ldw_active": bool(ldw_status.get("warning_active"))
+            or any(e.get("feature") == "LDW" for e in events),
+            "acc_active": bool(acc_status.get("active") or acc_status.get("enabled")),
+            "aeb_warning": bool(aeb_status.get("braking_active")) or len(braking) > 0,
+            "bsd_left": bsd_left,
+            "bsd_right": bsd_right,
+            "tsr_detected": tsr_detected,
+            "parking_active": bool(parking_status.get("active")),
         },
         "warnings_triggered": len(warnings),
         "emergency_events": len(braking),
-        "camera_view": "front",
+        "camera_view": camera_view,
+        "tsr": {
+            "speed_limit_kmh": tsr_limit,
+            "signs_detected": tsr_status.get("signs_detected", 0),
+            "warning_signs": tsr_status.get("warning_signs", []),
+        },
     }

--- a/docs/REVIEW_AND_FEEDBACK.md
+++ b/docs/REVIEW_AND_FEEDBACK.md
@@ -1,0 +1,139 @@
+# Review & Feedback — Automotive ADAS + Infotainment System
+
+**Date:** 2026-08-10  
+**Scope:** Software-only ADAS SIL + Radio Display / Camera ECU simulation targeting Android Automotive–compatible infotainment  
+**Audience:** Maintainers reviewing progress outside of chat history  
+
+---
+
+## Executive verdict
+
+The repository is a coherent **Software-in-the-Loop (SIL)** stack (Python sim → FastAPI → React web / Expo mobile) with a solid scenario/test-case catalog. Before this pass, several core control loops were effectively dead (ACC/TSR never enabled from config, reverse impossible, parking/trailer steering unused, BSD/TSR sensor contracts broken, Radio Display stubbed). Those blockers are addressed in code on this branch. Remaining gaps are mainly **Android Automotive OS (AAOS) packaging**, richer HMI (media/nav), MIL runner completeness, and production API hosting for GitHub Pages.
+
+---
+
+## Architecture (as designed)
+
+```text
+web-app (React/Vite)  ──┐
+mobile-app (Expo RN)  ──┼── REST ──► backend/api (FastAPI)
+                        │                │
+                        │                ▼
+                        │         ADAS_SIL_System
+                        │         ├── VehicleDynamics (+ gear / reverse)
+                        │         ├── Sensors (front/left/right/rear radar + front camera)
+                        │         └── ADAS: LDW, ACC, AEB, BSD, Parking, Trailer, SVC, TSR
+```
+
+**ECU surfaces promised by README**
+
+| Surface | Intent | Status after this pass |
+|---------|--------|------------------------|
+| Radio Display | Speed, ADAS icons, TSR overlay, warnings | **Live from sim results** (was stubbed) |
+| ADAS Camera | Multi-camera + detection | UI mosaic + API metadata; still SVG/decorative feeds |
+| Dynamics / ADAS | Scenario-driven SIL | Core enable/control/schema bugs fixed |
+
+---
+
+## Bugs fixed in this branch
+
+### Simulation engine
+
+1. **ACC ignored `config.enabled`** — always started disabled; never called `enable()`. Now honors config and activates after scenario load.
+2. **TSR ignored `config.enabled`** — same pattern; now enables with config / load.
+3. **Camera ↔ TSR schema mismatch** — camera emits `sign_type` / `sign_value` / `range`; TSR expected `sign_class` / `distance`. Also crashed on `position` dict via eager `get` default. Fixed with `_resolve_sign_type` and safe position defaults.
+4. **No reverse motion** — `vx = max(0, vx)` blocked trailer/SVC reverse. Added gear (`P/R/N/D`) and signed longitudinal dynamics.
+5. **Parking / trailer steering never applied** — `_compute_vehicle_controls` only used AEB/ACC. Added priority stack: AEB → parking → trailer → ACC (+ mild LDW nudge).
+6. **BSD could not consume radar** — required `classification` + global `x/y`. Radar now emits vehicle-frame `x/y`, `azimuth`, `classification`; BSD accepts range/azimuth.
+7. **Only front radar** — blind-spot traffic invisible. Added left/right/rear radars; FOV honors sensor mount yaw.
+8. **`vehicle_approaching` unimplemented** — BSD scenarios no-oped. Engine now spawns adjacent/rear actors.
+9. **MIL-style `vehicle_config` ignored by API path** — `load_scenario` now accepts MIL initial speed/position.
+10. **`get_results` only logged LDW/AEB** — now also ACC/BSD/TSR/parking/trailer (downsampled).
+
+### Backend API
+
+11. **Radio Display always showed 0 km/h / hard-coded icons** — derived from last trace + final ADAS status.
+12. **`/simulate` omitted parking/trailer features** — enabled in default sim config.
+13. **Unhandled sim/JSON failures → opaque 500s** — try/except with 400/500 detail.
+14. **Response key inconsistency** — `/simulate` now also returns `radio_display_state` alias.
+
+### Web / mobile
+
+15. **Web Simulation hid API errors** — error card added.
+16. **RadioDisplay / CameraView static** — RadioDisplay accepts live `state`; CameraView lists 5 cameras consistently.
+17. **“Last test” used `Object.values().slice(-1)`** — wrong after re-runs; tracked via `lastTestId`.
+18. **Mobile missing scenarios** — added highway TSR + perpendicular parking.
+19. **Mobile deps** — declared `expo-constants`, `react-native-gesture-handler`; cleartext + orientation notes for AAOS path.
+
+---
+
+## Remaining feedback (prioritized)
+
+### P0 — Android Automotive compatibility (goal gap)
+
+The Expo app is still a **phone** package (`com.adasinfotainment.app`), not an AAOS system/HMI app.
+
+| Gap | Why it matters | Recommended next step |
+|-----|----------------|------------------------|
+| No `android.hardware.type.automotive` | Not installable/recognized as automotive | Expo config plugin or bare `android/` manifest |
+| No Car App Library / templates | Distraction-optimized UX required for many AAOS surfaces | Add `androidx.car.app` park-mode screens for tests/sim |
+| Landscape / IVI layout | Head units are wide; bottom tabs are phone UX | Landscape-first IVI shell (large targets, driver-safe) |
+| Touchscreen optional | Many AAOS images mark touchscreen not required | `uses-feature touchscreen required=false` |
+| Emulator CI | Never validated on Automotive system image | AAOS emulator smoke in `mobile-build.yml` |
+| Backend reachability | `10.0.2.2` + cleartext is emulator-dev only | Build flavors: emulator / device LAN / HTTPS |
+
+**Honest assessment:** software ADAS/Radio Display logic can run on AAOS as an APK, but **shipping as an Android Automotive–compatible infotainment system** needs native packaging + HMI rules above — not only React Native UI.
+
+### P1 — Product / ECU completeness
+
+- **Dashboard still mostly static** until a simulation is run on the Simulation page; wire shared state or poll `/radio-display` health + last run store.
+- **Camera feeds are decorative** — no image pipeline from surround_view; acceptable for SIL demo, not for vision validation.
+- **No media / tuner / nav** — “Radio Display” is ADAS chrome, not a media session (important if targeting AAOS media apps).
+- **GitHub Pages demo has no API** — `VITE_API_BASE_URL` unset in CI; Run buttons fail in production. Host API or disable/gated UI when `/` health fails.
+- **Collision model missing** — after AEB, ACC can re-accelerate through a stopped lead once FOV is lost. Add occupancy / post-AEB hold.
+
+### P2 — Scenario / MIL pipeline
+
+- Two scenario formats (engine vs MIL) still coexist. API now best-effort parses MIL events; full MIL validation still lives in `core/mil_testing.py` and does **not** feed injected detections into `step()`.
+- Parking space detection heuristics and surround auto-switch on gear need deeper MIL command coverage (`start_parking`, `set_auto_switching`).
+- Environment actors still primarily advance along world +X (limited yaw-aware motion).
+
+### P3 — Engineering hygiene
+
+- Visualization extras (`matplotlib`, `websockets`) not in requirements — gate or add optional extras.
+- Unit tests historically assert “enabled after update” more than behavior; add regressions for ACC control, TSR camera schema, reverse gear, BSD radar polar detections, radio display speed.
+- Sync `package-lock.json` after mobile dependency adds before CI install.
+
+---
+
+## Suggested roadmap (technical, not calendar)
+
+1. **AAOS packaging spike** — config plugin + Automotive emulator install of the APK; landscape IVI shell.
+2. **Shared app state** — last simulation → Dashboard Radio/Camera; API health indicator.
+3. **Hosted backend** for Pages demo or document UI-only mode.
+4. **Unify scenario schema** + finish MIL injection into `simulator.step`.
+5. **Safety arbitration** — post-AEB ACC inhibit / simple collision.
+6. **Behavioral tests** asserting AEB event, BSD occupied, TSR limit, reverse trailer active.
+
+---
+
+## How to verify this branch
+
+```bash
+# From repo root
+python -m venv .venv && source .venv/bin/activate
+pip install -r backend/requirements.txt -r ADAS_SIL_System/requirements.txt
+pytest backend/tests/ ADAS_SIL_System/tests/ -v
+
+# Manual API smoke
+uvicorn backend.api.main:app --port 8000
+# POST /simulate {"scenario":"emergency_braking","duration":5,"dt":0.1}
+# Expect radio_display.speed_display.current_speed_kmh != stub-only zeros when ego moves
+# Expect adas_events may include AEB/ACC
+```
+
+---
+
+## Summary for stakeholders
+
+You asked for a **fully functional software infotainment system compatible with Android Automotive**. This branch makes the **SIL + ECU visualization path functionally honest** (features enable, reverse exists, controls apply, sensors feed BSD/TSR, Radio Display reflects sim). AAOS **compatibility** is started (orientation/cleartext/deps notes) but **not complete** until automotive manifest, landscape IVI UX, and preferably Car App Library / emulator validation land. Treat the checklist in **P0** as the remaining gate for “Android Automotive compatible.”

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -3,17 +3,25 @@
     "name": "ADAS Infotainment",
     "slug": "adas-infotainment",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "userInterfaceStyle": "dark",
     "splash": {
       "backgroundColor": "#0f1923"
     },
     "android": {
       "package": "com.adasinfotainment.app",
-      "versionCode": 1
+      "versionCode": 1,
+      "permissions": [],
+      "softwareKeyboardLayoutMode": "pan",
+      "allowBackup": false,
+      "usesCleartextTraffic": true
     },
     "extra": {
-      "apiBaseUrl": "http://10.0.2.2:8000"
+      "apiBaseUrl": "http://10.0.2.2:8000",
+      "automotive": {
+        "target": "android_automotive",
+        "notes": "Manifest automotive features require a config plugin or bare android/ project. See docs/REVIEW_AND_FEEDBACK.md."
+      }
     },
     "plugins": []
   }

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "expo": "~50.0.0",
+    "expo-constants": "~15.4.5",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
     "react-native": "0.73.2",
+    "react-native-gesture-handler": "~2.14.0",
     "react-native-svg": "^14.1.0",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/bottom-tabs": "^6.5.11",

--- a/mobile-app/src/screens/SimulationScreen.js
+++ b/mobile-app/src/screens/SimulationScreen.js
@@ -10,8 +10,10 @@ const SCENARIOS = [
   { name: 'emergency_braking', label: 'Emergency Braking' },
   { name: 'blind_spot_detection', label: 'Blind Spot Detection' },
   { name: 'city_driving_tsr', label: 'City Driving (TSR)' },
+  { name: 'highway_driving_tsr', label: 'Highway (TSR)' },
   { name: 'surround_view_camera', label: 'Surround View' },
   { name: 'autonomous_parking_parallel', label: 'Parking - Parallel' },
+  { name: 'autonomous_parking_perpendicular', label: 'Parking - Perpendicular' },
   { name: 'trailer_assistance', label: 'Trailer Assistance' },
 ];
 

--- a/mobile-app/src/screens/TestCasesScreen.js
+++ b/mobile-app/src/screens/TestCasesScreen.js
@@ -7,6 +7,7 @@ const API_BASE = getApiBaseUrl();
 export default function TestCasesScreen() {
   const [testCases, setTestCases] = useState([]);
   const [results, setResults] = useState({});
+  const [lastTestId, setLastTestId] = useState(null);
   const [running, setRunning] = useState(null);
   const [listError, setListError] = useState(null);
 
@@ -45,8 +46,10 @@ export default function TestCasesScreen() {
       }
       const data = await res.json();
       setResults((prev) => ({ ...prev, [tc.id]: data }));
+      setLastTestId(tc.id);
     } catch (error) {
       setResults((prev) => ({ ...prev, [tc.id]: { status: 'ERROR', error: error.message } }));
+      setLastTestId(tc.id);
     }
     setRunning(null);
   };
@@ -59,7 +62,7 @@ export default function TestCasesScreen() {
 
   const passCount = Object.values(results).filter((r) => r.status === 'PASS').length;
   const totalRun = Object.keys(results).length;
-  const lastResult = Object.values(results).slice(-1)[0];
+  const lastResult = lastTestId ? results[lastTestId] : null;
   const lastChecks = lastResult?.validation?.checks || [];
 
   return (

--- a/web-app/src/components/CameraView.jsx
+++ b/web-app/src/components/CameraView.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
 
-export default function CameraView() {
+/**
+ * ADAS camera mosaic.
+ * Aligns with backend /adas-cameras (5 cameras including cargo).
+ */
+export default function CameraView({ activeCameras = null, detectionCount = null }) {
   const cameras = [
     { name: 'Front', status: 'active' },
     { name: 'Rear', status: 'active' },
     { name: 'Left', status: 'active' },
     { name: 'Right', status: 'active' },
+    { name: 'Cargo', status: 'active' },
   ];
+
+  const activeCount = activeCameras?.length || cameras.length;
 
   return (
     <div>
@@ -14,16 +21,13 @@ export default function CameraView() {
         {cameras.map((cam) => (
           <div key={cam.name} className="camera-feed">
             <svg width="100%" height="100%" viewBox="0 0 160 90">
-              {/* Simulated camera feed visualization */}
               <rect width="160" height="90" fill="#050a10" />
-              {/* Road lines */}
               {cam.name === 'Front' && (
                 <g>
                   <line x1="40" y1="90" x2="70" y2="40" stroke="#334" strokeWidth="1" />
                   <line x1="120" y1="90" x2="90" y2="40" stroke="#334" strokeWidth="1" />
                   <line x1="70" y1="40" x2="75" y2="30" stroke="#334" strokeWidth="0.5" strokeDasharray="3 2" />
                   <line x1="90" y1="40" x2="85" y2="30" stroke="#334" strokeWidth="0.5" strokeDasharray="3 2" />
-                  {/* Detection box */}
                   <rect x="65" y="35" width="30" height="20" fill="none" stroke="#00d4ff" strokeWidth="0.5" />
                   <text x="80" y="60" textAnchor="middle" fill="#00d4ff" fontSize="5">Vehicle</text>
                 </g>
@@ -34,14 +38,23 @@ export default function CameraView() {
                   <line x1="130" y1="0" x2="100" y2="90" stroke="#334" strokeWidth="1" />
                 </g>
               )}
+              {cam.name === 'Cargo' && (
+                <g>
+                  <rect x="50" y="25" width="60" height="40" fill="none" stroke="#445" strokeWidth="1" strokeDasharray="4 2" />
+                  <text x="80" y="50" textAnchor="middle" fill="#7a8fa0" fontSize="6">Cargo bay</text>
+                </g>
+              )}
               <text x="80" y="85" textAnchor="middle" fill="#7a8fa0" fontSize="7">{cam.name} Camera</text>
             </svg>
           </div>
         ))}
       </div>
       <div style={{ marginTop: '0.75rem', display: 'flex', justifyContent: 'space-between', fontSize: '0.7rem', color: '#7a8fa0' }}>
-        <span>5 cameras active</span>
-        <span>Object detection: ON</span>
+        <span>{activeCount} cameras configured</span>
+        <span>
+          Object detection: ON
+          {detectionCount != null ? ` (${detectionCount})` : ''}
+        </span>
       </div>
     </div>
   );

--- a/web-app/src/components/RadioDisplay.jsx
+++ b/web-app/src/components/RadioDisplay.jsx
@@ -1,35 +1,89 @@
 import React from 'react';
 
-export default function RadioDisplay() {
+/**
+ * Radio Display ECU visualization.
+ * Pass `state` from /simulate or /test-cases/run (radio_display / radio_display_state).
+ */
+export default function RadioDisplay({ state = null }) {
+  const speed = state?.speed_display?.current_speed_kmh ?? 0;
+  const limit = state?.speed_display?.speed_limit_kmh ?? state?.tsr?.speed_limit_kmh;
+  const icons = state?.adas_icons || {};
+
+  const tiles = [
+    {
+      key: 'ACC',
+      label: icons.acc_active ? 'Active' : 'Off',
+      on: !!icons.acc_active,
+      color: '#00e676',
+    },
+    {
+      key: 'LDW',
+      label: icons.ldw_active ? 'Warning' : 'Ready',
+      on: !!icons.ldw_active,
+      color: icons.ldw_active ? '#ffb74d' : '#00d4ff',
+    },
+    {
+      key: 'AEB',
+      label: icons.aeb_warning ? 'Warning' : 'Ready',
+      on: !!icons.aeb_warning,
+      color: icons.aeb_warning ? '#ff5252' : '#00e676',
+    },
+    {
+      key: 'BSD',
+      label: icons.bsd_left || icons.bsd_right
+        ? `${icons.bsd_left ? 'L' : ''}${icons.bsd_left && icons.bsd_right ? '/' : ''}${icons.bsd_right ? 'R' : ''}`
+        : 'Clear',
+      on: !!(icons.bsd_left || icons.bsd_right),
+      color: '#ffb74d',
+    },
+    {
+      key: 'TSR',
+      label: icons.tsr_detected ? (limit != null ? `${limit}` : 'Sign') : '—',
+      on: !!icons.tsr_detected,
+      color: '#00d4ff',
+    },
+    {
+      key: 'PRK',
+      label: icons.parking_active ? 'Active' : 'Ready',
+      on: !!icons.parking_active,
+      color: '#ce93d8',
+    },
+  ];
+
   return (
     <div style={{ background: '#050a10', borderRadius: '8px', padding: '1rem', border: '1px solid rgba(0,212,255,0.2)' }}>
-      {/* Speed display */}
       <div style={{ textAlign: 'center', marginBottom: '1rem' }}>
         <div style={{ fontSize: '2.5rem', fontWeight: '700', color: '#fff', fontFamily: 'monospace' }}>
-          0 <span style={{ fontSize: '1rem', color: '#7a8fa0' }}>km/h</span>
+          {Number(speed).toFixed(0)}{' '}
+          <span style={{ fontSize: '1rem', color: '#7a8fa0' }}>km/h</span>
         </div>
+        {limit != null && (
+          <div style={{ fontSize: '0.75rem', color: '#00d4ff', marginTop: '0.25rem' }}>
+            Limit {limit} km/h
+          </div>
+        )}
       </div>
 
-      {/* ADAS Icons */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '0.5rem', marginBottom: '1rem' }}>
-        <div style={{ textAlign: 'center', padding: '0.5rem', borderRadius: '4px', background: 'rgba(0,230,118,0.1)' }}>
-          <div style={{ fontSize: '1.2rem' }}>ACC</div>
-          <div style={{ fontSize: '0.65rem', color: '#00e676' }}>Active</div>
-        </div>
-        <div style={{ textAlign: 'center', padding: '0.5rem', borderRadius: '4px', background: 'rgba(0,212,255,0.1)' }}>
-          <div style={{ fontSize: '1.2rem' }}>LDW</div>
-          <div style={{ fontSize: '0.65rem', color: '#00d4ff' }}>Ready</div>
-        </div>
-        <div style={{ textAlign: 'center', padding: '0.5rem', borderRadius: '4px', background: 'rgba(0,230,118,0.1)' }}>
-          <div style={{ fontSize: '1.2rem' }}>AEB</div>
-          <div style={{ fontSize: '0.65rem', color: '#00e676' }}>Ready</div>
-        </div>
+        {tiles.map((tile) => (
+          <div
+            key={tile.key}
+            style={{
+              textAlign: 'center',
+              padding: '0.5rem',
+              borderRadius: '4px',
+              background: tile.on ? `${tile.color}22` : 'rgba(255,255,255,0.04)',
+            }}
+          >
+            <div style={{ fontSize: '1rem' }}>{tile.key}</div>
+            <div style={{ fontSize: '0.65rem', color: tile.on ? tile.color : '#7a8fa0' }}>{tile.label}</div>
+          </div>
+        ))}
       </div>
 
-      {/* Status bar */}
       <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.7rem', color: '#7a8fa0', borderTop: '1px solid rgba(255,255,255,0.06)', paddingTop: '0.5rem' }}>
         <span>Radio Display ECU</span>
-        <span>1920x720 @ 60Hz</span>
+        <span>{state?.camera_view ? `View: ${state.camera_view}` : '1920x720 @ 60Hz'}</span>
       </div>
     </div>
   );

--- a/web-app/src/pages/Simulation.jsx
+++ b/web-app/src/pages/Simulation.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import VehicleVisualizer from '../components/VehicleVisualizer';
+import RadioDisplay from '../components/RadioDisplay';
 import { apiRequest } from '../lib/api';
 
 const SCENARIOS = [
@@ -34,6 +35,8 @@ export default function Simulation() {
     }
     setLoading(false);
   };
+
+  const radioState = result?.radio_display || result?.radio_display_state;
 
   return (
     <div>
@@ -80,6 +83,17 @@ export default function Simulation() {
           <VehicleVisualizer trace={result?.vehicle_trace} />
         </div>
 
+        {result?.error && (
+          <div className="card">
+            <div className="card-header"><h3>Error</h3></div>
+            <p style={{ color: '#ff8a80', margin: 0 }}>{result.error}</p>
+            <p className="page-subtitle" style={{ marginTop: '0.75rem' }}>
+              Ensure the backend is running (uvicorn backend.api.main:app --port 8000)
+              and VITE_API_BASE_URL points to it in production builds.
+            </p>
+          </div>
+        )}
+
         {result && !result.error && (
           <>
             <div className="card">
@@ -98,7 +112,7 @@ export default function Simulation() {
                   <div className="metric-label">ADAS Events</div>
                 </div>
                 <div>
-                  <div className="metric-value">{result.radio_display?.warnings_triggered || 0}</div>
+                  <div className="metric-value">{radioState?.warnings_triggered || 0}</div>
                   <div className="metric-label">Warnings</div>
                 </div>
               </div>
@@ -106,18 +120,7 @@ export default function Simulation() {
 
             <div className="card">
               <div className="card-header"><h3>Radio Display State</h3></div>
-              <div className="ecu-indicator">
-                <div className="ecu-dot" />
-                <span>LDW: {result.radio_display?.adas_icons?.ldw_active ? 'ACTIVE' : 'Ready'}</span>
-              </div>
-              <div className="ecu-indicator">
-                <div className="ecu-dot" />
-                <span>ACC: {result.radio_display?.adas_icons?.acc_active ? 'ACTIVE' : 'Off'}</span>
-              </div>
-              <div className="ecu-indicator">
-                <div className="ecu-dot" style={{ background: result.radio_display?.adas_icons?.aeb_warning ? '#ff5252' : '#00e676' }} />
-                <span>AEB: {result.radio_display?.adas_icons?.aeb_warning ? 'WARNING' : 'Ready'}</span>
-              </div>
+              <RadioDisplay state={radioState} />
             </div>
           </>
         )}

--- a/web-app/src/pages/TestCases.jsx
+++ b/web-app/src/pages/TestCases.jsx
@@ -5,6 +5,7 @@ import { apiRequest } from '../lib/api';
 export default function TestCases() {
   const [testCases, setTestCases] = useState([]);
   const [results, setResults] = useState({});
+  const [lastTestId, setLastTestId] = useState(null);
   const [running, setRunning] = useState(null);
   const [loadingCases, setLoadingCases] = useState(false);
   const [listError, setListError] = useState(null);
@@ -40,11 +41,13 @@ export default function TestCases() {
         }),
       });
       setResults((prev) => ({ ...prev, [tc.id]: data }));
+      setLastTestId(tc.id);
     } catch (error) {
       setResults((prev) => ({
         ...prev,
         [tc.id]: { status: 'ERROR', error: error.message },
       }));
+      setLastTestId(tc.id);
     }
     setRunning(null);
   };
@@ -55,7 +58,7 @@ export default function TestCases() {
     }
   };
 
-  const lastResult = Object.values(results).slice(-1)[0];
+  const lastResult = lastTestId ? results[lastTestId] : null;
   const lastChecks = lastResult?.validation?.checks || [];
   const passedChecks = lastChecks.filter((check) => check.passed).length;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Explored the Automotive ADAS + Infotainment SIL stack and fixed blockers that prevented a functional Radio Display / ADAS Camera ECU simulation. Captured lasting review feedback in `docs/REVIEW_AND_FEEDBACK.md` (also linked from README).

## Key bug fixes

- **ACC / TSR** honor `config.enabled` and activate after scenario load
- **Reverse gear** on vehicle dynamics (trailer / surround reverse paths)
- **Control arbitration** applies parking + trailer steering (AEB > parking > trailer > ACC)
- **Camera ↔ TSR** schema alignment (`sign_type`/`sign_value`/`range`) and safe position defaults
- **BSD** consumes radar polar detections; **side/rear radars** + FOV mount orientation
- **`vehicle_approaching`** and MIL-style `vehicle_config` supported on the engine/API path
- **Radio Display** derived from live speed + ADAS status (was stubbed zeros / hard-coded icons)
- Web error UI, live RadioDisplay props, camera count consistency, last-test tracking
- Mobile: missing scenarios, deps, cleartext/orientation notes toward AAOS

## Review document

See **`docs/REVIEW_AND_FEEDBACK.md`** for:

- Architecture verdict
- Bugs fixed vs remaining gaps
- **Android Automotive OS compatibility checklist** (manifest, Car App Library, landscape IVI, emulator CI)
- Recommended technical roadmap

## Verification

- `pytest ADAS_SIL_System/tests/ backend/tests/` — **85 passed**
- `web-app` production build succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94d8be43-74fe-47c0-99fc-62af628a13bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94d8be43-74fe-47c0-99fc-62af628a13bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

